### PR TITLE
fix: enable deploy by adding write permissions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch: # Allows manual trigger of the workflow in GitHub Actions UI
 
+permissions:
+contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Actions failed to push to gh-pages because the workflow lacked the required permissions. Added 'permissions: contents: write' to allow deploying the Docusaurus site.