### PR TITLE
chore: simplify deploy workflow using GITHUB_TOKEN

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -54,8 +54,5 @@ jobs:
       - name: Deploy Docusaurus using Gradle
         run: ./gradlew deployDocusaurus
         env:
-          GIT_USER_NAME: nklomp
-          GIT_USER_EMAIL: nklomp@4sure.tech
-          GIT_USER:  ${{ secrets.GIT_USER }}
-          GIT_PASS: ${{ secrets.GIT_PASS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Removed hardcoded user credentials (GIT_USER_NAME, GIT_PASS) from the deploy workflow. Replaced them with GITHUB_TOKEN and added permissions: write to enable safe deployment to gh-pages.

This makes the workflow easier to maintain, more secure, and no longer dependent on personal secrets.