### PR TITLE
fix: correct YAML indentation for permissions block

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: # Allows manual trigger of the workflow in GitHub Actions UI
 
 permissions:
-contents: write
+  contents: write
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixed an indentation error in the permissions block of github-pages.yml. The incorrect format caused the workflow to be invalid and skipped by GitHub Actions.

Corrected:
permissions:
  contents: write

This ensures the workflow has the required rights to deploy to gh-pages using GITHUB_TOKEN.