### PR TITLE
fix: correct indentation in deploy step for valid workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -57,12 +57,12 @@ jobs:
 
       # Step 6: Deploy Docusaurus using npx and GITHUB_TOKEN
       - name: Deploy Docusaurus using npx and GITHUB_TOKEN
-      run: |
-        git config --global user.email "actions@github.com"
-        git config --global user.name "GitHub Actions"
-        git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/FIDEScommunity/universal-oid4vp.git
-        npx docusaurus deploy
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/FIDEScommunity/universal-oid4vp.git
+          npx docusaurus deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 


### PR DESCRIPTION
Fixed the indentation of the 'run' and 'env' blocks under the deploy step. Incorrect YAML indentation was causing the GitHub Actions workflow to be invalid and skipped.

This change ensures the workflow is parsed correctly and the Docusaurus deployment step is executed with proper authentication.