### PR TITLE
chore: show npm debug log on Docusaurus deploy failure

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -61,7 +61,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/FIDEScommunity/universal-oid4vp.git
-          npx docusaurus deploy
+          npx docusaurus deploy || (echo "🔴 Docusaurus deploy failed. Showing npm log:" && cat /home/runner/.npm/_logs/* && exit 1)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Wrapped 'npx docusaurus deploy' in a fallback command to print the npm debug log if the deploy fails. This helps diagnose hidden errors inside the GitHub Actions runner, such as git push failures, config issues, or missing dependencies.

The error log will now be printed from /home/runner/.npm/_logs/* before the job exits.