### PR TITLE
fix: switch to npm run deploy for Docusaurus v3 compatibility

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -61,7 +61,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/FIDEScommunity/universal-oid4vp.git
-          npx docusaurus deploy || (echo "🔴 Docusaurus deploy failed. Showing npm log:" && cat /home/runner/.npm/_logs/* && exit 1)
+          npm run deploy || (echo "🔴 Docusaurus deploy failed. Showing npm log:" && cat /home/runner/.npm/_logs/* && exit 1)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Replaced 'npx docusaurus deploy' with 'npm run deploy' to resolve an execution error. Docusaurus v3 does not expose a CLI binary directly, but runs via a defined npm script. This ensures the deploy step executes correctly in CI.