### PR TITLE
fix: point Docusaurus docs path to documentation/docs folder

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -63,9 +63,11 @@ const config: Config = {
             'classic',
             {
                 docs: {
-                    sidebarPath: require.resolve('./sidebars.ts'),
-//                    docItemComponent: "@theme/ApiItem", // Derived from doc
+                  path: 'documentation/docs',
+                  sidebarPath: require.resolve('./sidebars.ts'),
+                //  docItemComponent: "@theme/ApiItem", // Optional, kun je laten staan of weghalen
                 },
+
                 blog: false,
                 /*blog: {
                     showReadingTime: true,


### PR DESCRIPTION
Corrected the docs plugin path to match actual file location. This resolves the "Page not found" error for /docs/universal-oid4vp-introduction.